### PR TITLE
Fix erroneous warning in traceplot (#989)

### DIFF
--- a/arviz/plots/backends/matplotlib/traceplot.py
+++ b/arviz/plots/backends/matplotlib/traceplot.py
@@ -271,7 +271,6 @@ def _plot_chains_mpl(
                 fill_kwargs=fill_kwargs,
                 rug_kwargs=rug_kwargs,
                 backend="matplotlib",
-                backend_kwargs={},
                 show=False,
             )
 
@@ -287,6 +286,5 @@ def _plot_chains_mpl(
             fill_kwargs=fill_kwargs,
             rug_kwargs=rug_kwargs,
             backend="matplotlib",
-            backend_kwargs={},
             show=False,
         )


### PR DESCRIPTION
* Fix erroneous warning in traceplot

* remove backend_kwarg from plot_dist call

Co-authored-by: Ari Hartikainen <ahartikainen@users.noreply.github.com>